### PR TITLE
Fix failure when eReolen reservation does not have a date

### DIFF
--- a/custom_components/bibliotek_dk/library_api.py
+++ b/custom_components/bibliotek_dk/library_api.py
@@ -166,6 +166,10 @@ class Library:
 
         # Unpack into separate elements
         d, m, y = date
+
+        # Check that a date was received
+        if not d.isnumeric(): return None
+        
         # Cut the name of the month to the first 3 chars
         m = m[:3]
         # Change the few danish month to english

--- a/custom_components/bibliotek_dk/sensor.py
+++ b/custom_components/bibliotek_dk/sensor.py
@@ -120,9 +120,10 @@ class LibrarySensor(SensorEntity):
     @property
     def state(self):
         if len(self.myLibrary.user.loans) > 0:
-            return (
-                self.myLibrary.user.loans[0].expireDate.date() - datetime.now().date()
-            ).days
+            if self.myLibrary.user.loans[0].expireDate is not None: # eReolen reservation in Queue
+                return (
+                    self.myLibrary.user.loans[0].expireDate.date() - datetime.now().date()
+                ).days
         return ""
 
     @property


### PR DESCRIPTION
A reservation on eReolen can get queued without an expected date. This no long causes a failure. Still needs to be correctly handled as reservation